### PR TITLE
POC that this image can be usable _without_ a distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,28 @@
-FROM ubuntu
+FROM golang:1.16 as show-build
+COPY show.go .
+RUN go build -o /show show.go
+
+FROM ubuntu as build
 
 # perl is needed for shasum
 RUN apt-get -y update && apt-get install -y wget perl ca-certificates && update-ca-certificates && rm -rf /var/lib/apt/lists/*
 
 RUN bash -c "set -eo pipefail; wget -O- https://carvel.dev/install.sh | bash"
 
-RUN ytt version && kapp version && kbld version && kwt version && imgpkg version && vendir version
+RUN apt show ca-certificates >ca-certificates-version.txt
+
+FROM scratch
+# the tools use TLS: include the updated certs
+COPY --from=build /etc/ssl/certs /etc/ssl/certs
+COPY --from=build /ca-certificates-version.txt /ca-certificates-version.txt
+
+COPY --from=build /usr/local/bin/ytt /ytt
+COPY --from=build /usr/local/bin/kapp /kapp
+COPY --from=build /usr/local/bin/kbld /kbld
+COPY --from=build /usr/local/bin/kwt /kwt
+COPY --from=build /usr/local/bin/imgpkg /imgpkg
+COPY --from=build /usr/local/bin/vendir /vendir
+
+# ... to be able to view the certificates version file
+COPY --from=show-build /show /show
+

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Source for [docker.io/k14s/image](https://hub.docker.com/r/k14s/image) that includes various tools under k14s.
 
-Image is based on latest `ubuntu`. It includes:
+This is a distroless image. It contains:
 
 - [ytt](https://get-ytt.io)
 - [kbld](https://get-kbld.io)
@@ -12,8 +12,26 @@ Image is based on latest `ubuntu`. It includes:
 - [kwt](https://github.com/k14s/kwt)
 - [imgpkg](https://github.com/k14s/imgpkg)
 - [vendir](https://github.com/k14s/vendir)
+- ca-cert store (latest from Ubuntu)
 
-Note: please use reference found under `image` key in [`published.yml`](published.yml) (alternatively we started including `latest` tag).
+## Usage
+
+```bash
+docker pull k14s/image:latest
+```
+_(the exact digest reference can be found at `image:` in [`published.yml`](published.yml))_
+
+To verify the ca-cert store version:
+
+```bash
+docker run --rm k14s/image:latest /show ca-certificates-version.txt
+```
+
+Use a volume mount to make host files available to contained binaries:
+
+```bash
+docker run --rm -v $(pwd):/host k14s/image:latest /ytt -f /host/config --output-files=/host/output
+```
 
 ### Join the Community and Make Carvel Better
 Carvel is better because of our contributors and maintainers. It is because of you that we can bring great software to the community.

--- a/show.go
+++ b/show.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+    "fmt"
+    "io/ioutil"
+    "os"
+)
+
+func main() {
+    if len(os.Args) < 2 {
+        _, _ = fmt.Fprintf(os.Stderr, "usage: show (filename)")
+        os.Exit(1)
+    }
+
+    bs, err := ioutil.ReadFile(os.Args[1])
+    if err != nil {
+        _, _ = fmt.Fprintf(os.Stderr, "show: unable to read file \"%s\"", os.Args[1])
+        os.Exit(2)
+    }
+    fmt.Printf(string(bs))
+}


### PR DESCRIPTION
Exploring what it would take to make this image distroless.

Such images are not only less likely to contain vulnerabilities, but also reduce their total attack surface area _and_ the size of the image itself.